### PR TITLE
DSE-29255 - Log correct error message and removed extra logging

### DIFF
--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -687,7 +687,6 @@ class ProjectImporter(BaseWorkspaceInteractor):
             retry_limit=3,
         )
         self.remove_cdswctl_dir(cdswctl_path)
-        self.terminate_ssh_session()
 
     def terminate_ssh_session(self):
         logging.info("Terminating ssh connection.")


### PR DESCRIPTION
Log correct error message when project is not found.
Removed extra logging during exception. If the exception occurs before assigning the value to pexport and pimport object.