### PR TITLE
DSE-29254: Log project Name is the error message

### DIFF
--- a/cmlutils/cdswctl.py
+++ b/cmlutils/cdswctl.py
@@ -61,7 +61,7 @@ def obtain_cdswctl(host: str, ca_path: str) -> str:
 
 
 def cdswctl_login(cdswctl_path: str, host: str, username: str, api_key: str):
-    logging.info("Logging in to cdsw via cdswctl")
+    logging.info("Logging into cdsw via cdswctl")
     return subprocess.run(
         [cdswctl_path, "login", "-n", username, "-u", host, "-y", api_key]
     )

--- a/cmlutils/constants.py
+++ b/cmlutils/constants.py
@@ -50,9 +50,7 @@ class ApiV1Endpoints(Enum):
     API_KEY = "/api/v1/users/$username/apikey"
     RUNTIMES = "/api/v1/runtimes"
     USER_INFO = "/api/v1/users/$username"
-    PROJECTS_SUMMARY = (
-        "/api/v1/users/$username/projects-summary?all=true&context=$username"
-    )
+    PROJECTS_SUMMARY = "/api/v1/users/$username/projects-summary?all=true&context=$username&sortColumn=updated_at"
 
 
 """Mapping of old fields v1 to new fields of v2"""

--- a/cmlutils/project_entrypoint.py
+++ b/cmlutils/project_entrypoint.py
@@ -27,7 +27,6 @@ from cmlutils.validator import (
 def _configure_project_command_logging(log_filedir: str, project_name: str):
     os.makedirs(name=log_filedir, exist_ok=True)
     log_filename = log_filedir + constants.LOG_FILE
-    # extra = {'app_name': project_name}
     logging.basicConfig(
         handlers=[
             logging.StreamHandler(sys.stdout),

--- a/cmlutils/project_entrypoint.py
+++ b/cmlutils/project_entrypoint.py
@@ -24,9 +24,10 @@ from cmlutils.validator import (
 )
 
 
-def _configure_project_command_logging(log_filedir: str):
+def _configure_project_command_logging(log_filedir: str, project_name: str):
     os.makedirs(name=log_filedir, exist_ok=True)
     log_filename = log_filedir + constants.LOG_FILE
+    # extra = {'app_name': project_name}
     logging.basicConfig(
         handlers=[
             logging.StreamHandler(sys.stdout),
@@ -35,9 +36,17 @@ def _configure_project_command_logging(log_filedir: str):
             ),
         ],
         level=logging.INFO,
-        format="%(asctime)s - %(levelname)s - %(message)s",
+        format="%(asctime)s - %(levelname)s - %(custom_attribute)s - %(message)s",
         datefmt="%d/%m/%Y %H:%M:%S",
     )
+    old_factory = logging.getLogRecordFactory()
+
+    def record_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        record.custom_attribute = project_name
+        return record
+
+    logging.setLogRecordFactory(record_factory)
 
 
 def _read_config_file(file_path: str, project_name: str):
@@ -90,7 +99,7 @@ def project_export_cmd(project_name):
     ca_path = get_absolute_path(ca_path)
 
     log_filedir = os.path.join(output_dir, project_name, "logs")
-    _configure_project_command_logging(log_filedir)
+    _configure_project_command_logging(log_filedir, project_name)
     logging.info("Started exporting project: %s", project_name)
     try:
         # Get username of the creator of project - This is required so that admins can also migrate the project
@@ -106,7 +115,11 @@ def project_export_cmd(project_name):
         )
         creator_username, project_slug, owner_type = pobj.get_creator_username()
         if creator_username is None:
-            logging.error("Validation error: Cannot find project - %s under username %s", project_name, username)
+            logging.error(
+                "Validation error: Cannot find project - %s under username %s",
+                project_name,
+                username,
+            )
             raise RuntimeError("Validation error")
         logging.info("Begin validating for export.")
         validators = initialize_export_validators(
@@ -122,13 +135,17 @@ def project_export_cmd(project_name):
             validation_response = v.validate()
             if validation_response.validation_status == ValidationResponseStatus.FAILED:
                 logging.error(
-                    "Validation error: %s", validation_response.validation_msg
+                    "Validation error: %s",
+                    project_name,
+                    validation_response.validation_msg,
                 )
                 raise RuntimeError(
                     "validation error", validation_response.validation_msg
                 )
-        logging.info("Finished validating export validations.")
-        logging.info("File transfer for project and project metadata has started.")
+        logging.info(
+            "Finished validating export validations for project %s.", project_name
+        )
+        logging.info("File transfer has started.")
         pexport = ProjectExporter(
             host=url,
             username=creator_username,
@@ -171,7 +188,7 @@ def project_import_cmd(project_name):
     ca_path = get_absolute_path(ca_path)
 
     log_filedir = os.path.join(local_directory, project_name, "logs")
-    _configure_project_command_logging(log_filedir)
+    _configure_project_command_logging(log_filedir, project_name)
     p = ProjectImporter(
         host=url,
         username=username,
@@ -196,11 +213,16 @@ def project_import_cmd(project_name):
             validation_response = v.validate()
             if validation_response.validation_status == ValidationResponseStatus.FAILED:
                 logging.error(
-                    "Validation error: %s", validation_response.validation_msg
+                    "Validation error for project %s: %s",
+                    project_name,
+                    validation_response.validation_msg,
                 )
                 raise RuntimeError(
                     "validation error", validation_response.validation_msg
                 )
+        logging.info(
+            "Finished validating import validations for project %s.", project_name
+        )
         project_filepath = get_project_metadata_file_path(
             top_level_dir=local_directory, project_name=project_name
         )
@@ -213,7 +235,9 @@ def project_import_cmd(project_name):
 
         project_id = p.check_project_exist(project_metadata["name"])
         if project_id == None:
-            logging.info("Creating project to migrate files and metadata.")
+            logging.info(
+                "Creating project %s to migrate files and metadata.", project_name
+            )
             project_id = p.create_project_v2(proj_metadata=project_metadata)
         else:
             logging.warning(
@@ -237,7 +261,9 @@ def project_import_cmd(project_name):
 
         if uses_engine:
             proj_patch_metadata = {"default_project_engine_type": "legacy_engine"}
-            pimport.convert_project_to_engine_based(proj_patch_metadata=proj_patch_metadata)
+            pimport.convert_project_to_engine_based(
+                proj_patch_metadata=proj_patch_metadata
+            )
 
         pimport.import_metadata(project_id=project_id)
     except:

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -72,7 +72,9 @@ def get_ignore_files(
     )
     try:
         logging.info(
-            "The files included in %s will not be migrated", constants.FILE_NAME
+            "The files included in %s will not be migrated for the project %s",
+            constants.FILE_NAME,
+            project_name,
         )
         response = call_api_v1(
             host=host, endpoint=endpoint, method="GET", api_key=api_key, ca_path=ca_path
@@ -92,11 +94,13 @@ def get_ignore_files(
     except HTTPError as e:
         if e.response.status_code == 404:
             logging.warning(
-                "Export ignore file does not exist. Hence, all files will be migrated except .cache and .local."
+                "Export ignore file does not exist. Hence, all files of the project %s will be migrated except .cache and .local.",
+                project_name,
             )
             logging.info(
-                "A default %s is being created with default entries .cache and .local since, it does not exist",
+                "A default %s has been created in the project %s with default entries .cache and .local since, it does not exist.",
                 constants.FILE_NAME,
+                project_name,
             )
             entries_content = "\n".join(constants.DEFAULT_ENTRIES)
             create_command = [
@@ -149,6 +153,7 @@ def transfer_project_files(
     source: str,
     destination: str,
     retry_limit: int,
+    project_name: str,
     exclude_file_path: str = None,
 ):
     logging.info("Transfering files over ssh from sshport %s", sshport)
@@ -175,7 +180,9 @@ def transfer_project_files(
             return
         logging.warning("Got non zero return code. Retrying...")
     if return_code != 0:
-        logging.error("Retries exhausted for rsync.. Failing script")
+        logging.error(
+            "Retries exhausted for rsync.. Failing script for project %s", project_name
+        )
         raise RuntimeError("Retries exhausted for rsync.. Failing script")
 
 
@@ -190,7 +197,9 @@ def test_file_size(sshport: int, output_dir: str, exclude_file_path: str = None)
     s = os.statvfs(output_dir)
     localdir_size = (s.f_bavail * s.f_frsize) / 1024
     if float(file_size) > float(localdir_size):
-        logging.error("Not enough disk space to download the tar file.")
+        logging.error(
+            "Insufficient disk storage to download project files for the project."
+        )
         raise RuntimeError
 
 
@@ -434,6 +443,7 @@ class ProjectExporter(BaseWorkspaceInteractor):
             source=constants.CDSW_PROJECTS_ROOT_DIR,
             destination=project_data_dir,
             retry_limit=3,
+            project_name=self.project_name,
             exclude_file_path=exclude_file_path,
         )
         self.remove_cdswctl_dir(cdswctl_path)
@@ -560,7 +570,7 @@ class ProjectExporter(BaseWorkspaceInteractor):
         filepath = get_jobs_metadata_file_path(
             top_level_dir=self.top_level_dir, project_name=self.project_name
         )
-        logging.info("Exporting job metadata to path %s", filepath)
+        logging.info("Exporting job metadata to path %s ", filepath)
         job_list = self.get_jobs_listv1()
         if len(job_list) == 0:
             logging.info("Jobs are not present in the project %s.", self.project_name)

--- a/cmlutils/utils.py
+++ b/cmlutils/utils.py
@@ -51,7 +51,6 @@ def call_api_v1(
         resp.raise_for_status()  # Raise an exception for 4xx or 5xx errors
         return resp
     except requests.exceptions.RequestException as e:
-        logging.warning(f"Error: {e}")
         if resp != None and "application/json" in resp.headers.get("content-type"):
             logging.error("Error response from API: %s", resp.json())
         raise

--- a/cmlutils/validator.py
+++ b/cmlutils/validator.py
@@ -61,7 +61,7 @@ class DirectoriesAndFilesValidator(ImportValidators):
             )
         return ValidationResponse(
             validation_name=self.validation_name,
-            validation_msg="Expected files and directories present for the project",
+            validation_msg="Expected files and directories present",
             validation_status=ValidationResponseStatus.PASSED,
         )
 
@@ -100,21 +100,25 @@ class UserNameImportValidator(ImportValidators):
                 logging.error("Username does not exist %s", e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="The user name does not exist. Ensure that the user name provided is correct.",
+                    validation_msg="The user name does not exist. Ensure that the user name provided for the project {} is correct.".format(
+                        self.project_name
+                    ),
                     validation_status=ValidationResponseStatus.FAILED,
                 )
             elif e.response.status_code == 401:
                 logging.error("Unauthorized for url %s", e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="The user is unauthorised. Ensure that the API key is correct",
+                    validation_msg="The user is unauthorised. Ensure that the API key for the project {} is correct".format(
+                        self.project_name
+                    ),
                     validation_status=ValidationResponseStatus.FAILED,
                 )
             else:
                 logging.error(e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="Exception occurred while validating username.",
+                    validation_msg="Exception occurred while validating username",
                     validation_status=ValidationResponseStatus.FAILED,
                 )
 
@@ -188,21 +192,25 @@ class UsernameValidator(ExportValidators):
                 logging.error("Username does not exist %s", e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="The user name does not exist. Ensure that the user name provided is correct.",
+                    validation_msg="The user name does not exist. Ensure that the user name provided for the project {} is correct.".format(
+                        self.project_name
+                    ),
                     validation_status=ValidationResponseStatus.FAILED,
                 )
             elif e.response.status_code == 401:
                 logging.error("Unauthorized for url %s", e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="The user is unauthorised. Ensure that the API key is correct",
+                    validation_msg="The user is unauthorised. Ensure that the API key for the project {} is correct ".format(
+                        self.project_name
+                    ),
                     validation_status=ValidationResponseStatus.FAILED,
                 )
             else:
                 logging.error(e.response.json())
                 return ValidationResponse(
                     validation_name=self.validation_name,
-                    validation_msg="Exception occurred while validating username.",
+                    validation_msg="Exception occurred while validating username",
                     validation_status=ValidationResponseStatus.FAILED,
                 )
 
@@ -217,8 +225,8 @@ class ProjectBelongsToUserValidator(ExportValidators):
         ca_path: str,
         project_slug: str,
     ):
-        self.validation_name = "Validate if the project belongs to user {}".format(
-            username
+        self.validation_name = "Validate if the project {} belongs to user {}".format(
+            project_name, username
         )
         self.validation_name = "Check if user is present"
         self.host = host
@@ -249,7 +257,9 @@ class ProjectBelongsToUserValidator(ExportValidators):
             logging.error("Project does not exist")
             return ValidationResponse(
                 validation_name=self.validation_name,
-                validation_msg="Project does not exist. Ensure that the project name provided is correct.",
+                validation_msg="Project - {} does not exist. Ensure that the project name provided is correct.".format(
+                    self.project_name
+                ),
                 validation_status=ValidationResponseStatus.FAILED,
             )
 
@@ -313,12 +323,16 @@ class RsyncRuntimeAddonExistsExportValidator(ExportValidators):
         else:
             return ValidationResponse(
                 validation_name=self.validation_name,
-                validation_msg="Project is not configured with runtime",
+                validation_msg="Project {} is not configured with runtime".format(
+                    self.project_name
+                ),
                 validation_status=ValidationResponseStatus.SKIPPED,
             )
         return ValidationResponse(
             validation_name=self.validation_name,
-            validation_msg="Rsync enabled runtime is not added",
+            validation_msg="Rsync enabled runtime is not added in the project {}.".format(
+                self.project_name
+            ),
             validation_status=ValidationResponseStatus.FAILED,
         )
 


### PR DESCRIPTION
DSE-29257: Export ignore showing error and warning at the same time
DSE-28983: project-summary api behaving incorrectly - Need to handle it in utility

To support batch migration project anme should be logged in various messages to make it easier to figure out the respective logs. The bubbled up response from the API was shown initially, removed the same to ensure clear logging. As suggested during the API verification the required tags have been added to avoid failure scenarios of the project-summary api

Testing:
Tested locally via export of a project.
Log messages have added information of project name to it. Project summary api is working as expected.