### PR TITLE
DSE-29582: Import Script failing due to invalid arguments

### DIFF
--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -696,6 +696,7 @@ class ProjectImporter(BaseWorkspaceInteractor):
             ),
             destination=constants.CDSW_PROJECTS_ROOT_DIR,
             retry_limit=3,
+            project_name=self.project_name,
         )
         self.remove_cdswctl_dir(cdswctl_path)
 


### PR DESCRIPTION
Added the argument in the function call of transfer projects.

Testing:
Tested locally by importing a project from the third machine to the CML workspace.