### PR TITLE
DSE-29898 - Allow migration of application with same name

### DIFF
--- a/cmlutils/constants.py
+++ b/cmlutils/constants.py
@@ -20,6 +20,7 @@ PROJECT_NAME_KEY = "project_name"
 CA_PATH_KEY = "ca_path"
 MAX_API_PAGE_LENGTH = 30
 
+
 class ApiV2Endpoints(Enum):
     PROJECTS = "/api/v2/projects"
     CREATE_MODEL = "/api/v2/projects/$project_id/models"
@@ -28,12 +29,10 @@ class ApiV2Endpoints(Enum):
     STOP_APP = "/api/v2/projects/$project_id/applications/$application_id:stop"
     CREATE_JOB = "/api/v2/projects/$project_id/jobs"
     UPDATE_JOB = "/api/v2/projects/$project_id/jobs/$job_id"
-    SEARCH_PROJECT = "/api/v2/projects?search_filter=$search_option&include_public_projects=true&page_size=1000"
-    SEARCH_MODEL = "/api/v2/projects/$project_id/models?search_filter=$search_option&page_size=1000"
-    SEARCH_JOB = (
-        "/api/v2/projects/$project_id/jobs?search_filter=$search_option&page_size=1000"
-    )
-    SEARCH_APP = "/api/v2/projects/$project_id/applications?search_filter=$search_option&page_size=1000"
+    SEARCH_PROJECT = "/api/v2/projects?search_filter=$search_option&include_public_projects=true&page_size=100000"
+    SEARCH_MODEL = "/api/v2/projects/$project_id/models?search_filter=$search_option&page_size=100000"
+    SEARCH_JOB = "/api/v2/projects/$project_id/jobs?search_filter=$search_option&page_size=100000"
+    SEARCH_APP = "/api/v2/projects/$project_id/applications?search_filter=$search_option&page_size=100000"
     RUNTIME_ADDONS = "/api/v2/runtimeaddons?search_filter=$search_option"
     RUNTIMES = "/api/v2/runtimes?page_size=$page_size&page_token=$page_token"
 

--- a/cmlutils/legacy_engine_runtime_constants.py
+++ b/cmlutils/legacy_engine_runtime_constants.py
@@ -4,17 +4,19 @@ from json import load
 #  If the mapping is Empty, the workloads will be created with the default engine images. Hence,
 #  make this map empty in cases of default engine images scenario
 _LEGACY_ENGINE_RUNTIME_CONSTANTS = {
-    'python3': 'docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2022.11.2-b2',
-    'python2': 'docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2022.11.2-b2',
-    'r': 'docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-r4.1-standard:2022.11.2-b2',
-    'scala': 'docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-scala2.11-standard:2022.11.2-b2',
-    'default': "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2023.05.2-b7"
+    "python3": "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2022.11.2-b2",
+    "python2": "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2022.11.2-b2",
+    "r": "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-r4.1-standard:2022.11.2-b2",
+    "scala": "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-scala2.11-standard:2022.11.2-b2",
+    "default": "docker.repository.cloudera.com/cloudera/cdsw/ml-runtime-workbench-python3.9-standard:2023.05.2-b7",
 }
 
 
 def engine_to_runtime_map():
     # make sure this file is generated only via `cmlutil helpers populate_runtimes`
-    file_path = os.path.expanduser("~") + "/.cmlutils/legacy_engine_runtime_constants.json"
+    file_path = (
+        os.path.expanduser("~") + "/.cmlutils/legacy_engine_runtime_constants.json"
+    )
     if os.path.exists(file_path):
         data = open(file_path)
         engine_map = load(data)

--- a/cmlutils/project_entrypoint.py
+++ b/cmlutils/project_entrypoint.py
@@ -284,7 +284,8 @@ def project_helpers_cmd():
 def populate_engine_runtimes_mapping():
     project_name = "DEFAULT"
     config = _read_config_file(
-        os.path.expanduser("~") + "/.cmlutils/import-config.ini", project_name)
+        os.path.expanduser("~") + "/.cmlutils/import-config.ini", project_name
+    )
 
     username = config[USERNAME_KEY]
     url = config[URL_KEY]
@@ -312,7 +313,9 @@ def populate_engine_runtimes_mapping():
 
     response = p.get_all_runtimes_v2(page_token)
     if not response:
-        logging.info("populate_engine_runtimes_mapping: Get Runtimes API returned empty response")
+        logging.info(
+            "populate_engine_runtimes_mapping: Get Runtimes API returned empty response"
+        )
         return
     runtimes = response.get("runtimes", [])
     page_token = response.get("next_page_token", "")
@@ -327,17 +330,26 @@ def populate_engine_runtimes_mapping():
     if len(runtimes) > 0:
         legacy_runtime_image_map = parse_runtimes_v2(runtimes)
     else:
-        logging.error("populate_engine_runtimes_mapping: No runtimes present in the get_runtimes API response")
+        logging.error(
+            "populate_engine_runtimes_mapping: No runtimes present in the get_runtimes API response"
+        )
         return
 
     # Tries to create/overwrite the data present in <home-dir>/.cmlutils/legacy_engine_runtime_constants.json
     # Please make sure utility is having necessary permissions to write/overwrite data
     try:
-        with open(os.path.expanduser("~") + "/.cmlutils/" + 'legacy_engine_runtime_constants.json',
-                  'w') as legacy_engine_runtime_constants:
+        with open(
+            os.path.expanduser("~")
+            + "/.cmlutils/"
+            + "legacy_engine_runtime_constants.json",
+            "w",
+        ) as legacy_engine_runtime_constants:
             dump(legacy_runtime_image_map, legacy_engine_runtime_constants)
     except:
         logging.error(
             "populate_engine_runtimes_mapping: Please make sure Write Perms are set write/overwrite data."
             "Encountered Error during write/overwrite data in ",
-            os.path.expanduser("~") + "/.cmlutils/" + 'legacy_engine_runtime_constants.json')
+            os.path.expanduser("~")
+            + "/.cmlutils/"
+            + "legacy_engine_runtime_constants.json",
+        )

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -462,7 +462,9 @@ class ProjectExporter(BaseWorkspaceInteractor):
 
         if project_info_flatten[
             "default_project_engine_type"
-        ] == constants.LEGACY_ENGINE and not bool(legacy_engine_runtime_constants.engine_to_runtime_map()):
+        ] == constants.LEGACY_ENGINE and not bool(
+            legacy_engine_runtime_constants.engine_to_runtime_map()
+        ):
             project_metadata["default_project_engine_type"] = constants.LEGACY_ENGINE
 
         project_metadata["template"] = "blank"
@@ -513,13 +515,17 @@ class ProjectExporter(BaseWorkspaceInteractor):
                         if model_info_flatten["latestModelBuild.kernel"] != "":
                             runtime_identifier = legacy_engine_runtime_constants.engine_to_runtime_map().get(
                                 model_info_flatten["latestModelBuild.kernel"],
-                                legacy_engine_runtime_constants.engine_to_runtime_map().get("default"),
+                                legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                    "default"
+                                ),
                             )
                             model_metadata["runtime_identifier"] = runtime_identifier
                         else:
                             model_metadata[
                                 "runtime_identifier"
-                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                "default"
+                            )
                     else:
                         if model_info_flatten["latestModelBuild.kernel"] != "":
                             model_metadata["kernel"] = model_info_flatten[
@@ -528,7 +534,9 @@ class ProjectExporter(BaseWorkspaceInteractor):
                         else:
                             model_metadata[
                                 "runtime_identifier"
-                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                "default"
+                            )
 
             model_metadata_list.append(model_metadata)
         write_json_file(file_path=filepath, json_data=model_metadata_list)
@@ -556,9 +564,13 @@ class ProjectExporter(BaseWorkspaceInteractor):
                 # and the mapping should be given in LEGACY_ENGINE_MAP
                 # If the mapping is not given, the workloads will be created with the default engine images.
                 if bool(legacy_engine_runtime_constants.engine_to_runtime_map()):
-                    runtime_identifier = legacy_engine_runtime_constants.engine_to_runtime_map().get(
-                        app_info_flatten["currentDashboard.kernel"],
-                        legacy_engine_runtime_constants.engine_to_runtime_map().get("default"),
+                    runtime_identifier = (
+                        legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                            app_info_flatten["currentDashboard.kernel"],
+                            legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                "default"
+                            ),
+                        )
                     )
                     app_metadata["runtime_identifier"] = runtime_identifier
                 else:
@@ -590,7 +602,11 @@ class ProjectExporter(BaseWorkspaceInteractor):
                 if runtime_obj != None:
                     job_metadata.update(runtime_obj)
                 else:
-                    job_metadata["runtime_identifier"] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                    job_metadata[
+                        "runtime_identifier"
+                    ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                        "default"
+                    )
             else:
                 if (
                     job_info_flatten["project.default_project_engine_type"]
@@ -603,22 +619,32 @@ class ProjectExporter(BaseWorkspaceInteractor):
                         if job_info_flatten["kernel"] != "":
                             runtime_identifier = legacy_engine_runtime_constants.engine_to_runtime_map().get(
                                 job_info_flatten["kernel"],
-                                legacy_engine_runtime_constants.engine_to_runtime_map().get("default"),
+                                legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                    "default"
+                                ),
                             )
                             job_metadata["runtime_identifier"] = runtime_identifier
                         else:
                             job_metadata[
                                 "runtime_identifier"
-                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                "default"
+                            )
                     else:
                         if job_info_flatten["kernel"] != "":
                             job_metadata["kernel"] = job_info_flatten["kernel"]
                         else:
                             job_metadata[
                                 "runtime_identifier"
-                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                            ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                "default"
+                            )
                 else:
-                    job_metadata["runtime_identifier"] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                    job_metadata[
+                        "runtime_identifier"
+                    ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                        "default"
+                    )
 
             job_metadata_list.append(job_metadata)
 
@@ -905,8 +931,7 @@ class ProjectImporter(BaseWorkspaceInteractor):
 
     def get_all_runtimes_v2(self, page_token=""):
         endpoint = Template(ApiV2Endpoints.RUNTIMES.value).substitute(
-            page_size=constants.MAX_API_PAGE_LENGTH,
-            page_token=page_token
+            page_size=constants.MAX_API_PAGE_LENGTH, page_token=page_token
         )
 
         response = call_api_v2(
@@ -999,9 +1024,9 @@ class ProjectImporter(BaseWorkspaceInteractor):
             logging.error(f"Error: {e}")
             raise
 
-    def check_app_exist(self, app_name: str, proj_id: str) -> bool:
+    def check_app_exist(self, subdomain: str, proj_id: str) -> bool:
         try:
-            search_option = {"name": app_name}
+            search_option = {"subdomain": subdomain}
             encoded_option = urllib.parse.quote(
                 json.dumps(search_option).replace('"', '"')
             )
@@ -1018,7 +1043,7 @@ class ProjectImporter(BaseWorkspaceInteractor):
             app_list = response.json()["applications"]
             if app_list:
                 for app in app_list:
-                    if app["name"] == app_name:
+                    if app["subdomain"] == subdomain:
                         return True
             return False
         except KeyError as e:
@@ -1088,11 +1113,15 @@ class ProjectImporter(BaseWorkspaceInteractor):
                                 )
                                 logging.info(
                                     "Applying default runtime %s",
-                                    legacy_engine_runtime_constants.engine_to_runtime_map().get("default"),
+                                    legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                        "default"
+                                    ),
                                 )
                                 model_metadata[
                                     "runtime_identifier"
-                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                    "default"
+                                )
                         model_id = self.create_model_v2(
                             proj_id=project_id, model_metadata=model_metadata
                         )
@@ -1135,7 +1164,7 @@ class ProjectImporter(BaseWorkspaceInteractor):
             if app_metadata_list != None:
                 for app_metadata in app_metadata_list:
                     if not self.check_app_exist(
-                        app_name=app_metadata["name"], proj_id=project_id
+                        subdomain=app_metadata["subdomain"], proj_id=project_id
                     ):
                         app_metadata["project_id"] = project_id
                         if (
@@ -1155,7 +1184,9 @@ class ProjectImporter(BaseWorkspaceInteractor):
                             else:
                                 app_metadata[
                                     "runtime_identifier"
-                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                    "default"
+                                )
                         app_id = self.create_application_v2(
                             proj_id=project_id, app_metadata=app_metadata
                         )
@@ -1166,8 +1197,9 @@ class ProjectImporter(BaseWorkspaceInteractor):
                         )
                     else:
                         logging.info(
-                            "Skipping the already existing application- %s",
+                            "Skipping the already existing application %s with same subdomain- %s",
                             app_metadata["name"],
+                            app_metadata["subdomain"],
                         )
 
             return
@@ -1223,7 +1255,9 @@ class ProjectImporter(BaseWorkspaceInteractor):
                             else:
                                 job_metadata[
                                     "runtime_identifier"
-                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get("default")
+                                ] = legacy_engine_runtime_constants.engine_to_runtime_map().get(
+                                    "default"
+                                )
                         target_job_id = self.create_job_v2(
                             proj_id=project_id, job_metadata=job_metadata
                         )

--- a/cmlutils/utils.py
+++ b/cmlutils/utils.py
@@ -222,7 +222,9 @@ def get_absolute_path(path: str) -> str:
 
 
 def parse_runtimes_v2(runtimes):
-    legacy_runtime_image_map = _get_runtimes_v2(runtimes, editor="Workbench", edition="Standard")
+    legacy_runtime_image_map = _get_runtimes_v2(
+        runtimes, editor="Workbench", edition="Standard"
+    )
     return legacy_runtime_image_map
 
 
@@ -230,20 +232,32 @@ def _get_runtimes_v2(runtimes, editor="Workbench", edition="Standard"):
     legacy_runtime_image_map = {}
     legacy_runtime_kernel_map = {}
 
-    logging.info("Populating Engine to Runtimes Mapping for editor: %s, edition: %s", editor, edition)
+    logging.info(
+        "Populating Engine to Runtimes Mapping for editor: %s, edition: %s",
+        editor,
+        edition,
+    )
 
     for image_details in runtimes:
         if image_details["editor"] == editor and image_details["edition"] == edition:
             if "Python" in image_details["kernel"]:
                 if "python3" not in legacy_runtime_image_map:
                     legacy_runtime_kernel_map["python3"] = image_details["kernel"]
-                    legacy_runtime_image_map["python3"] = image_details["image_identifier"]
-                    legacy_runtime_image_map["python2"] = image_details["image_identifier"]
+                    legacy_runtime_image_map["python3"] = image_details[
+                        "image_identifier"
+                    ]
+                    legacy_runtime_image_map["python2"] = image_details[
+                        "image_identifier"
+                    ]
                 else:
                     if image_details["kernel"] > legacy_runtime_kernel_map["python3"]:
                         legacy_runtime_kernel_map["python3"] = image_details["kernel"]
-                        legacy_runtime_image_map["python3"] = image_details["image_identifier"]
-                        legacy_runtime_image_map["python2"] = image_details["image_identifier"]
+                        legacy_runtime_image_map["python3"] = image_details[
+                            "image_identifier"
+                        ]
+                        legacy_runtime_image_map["python2"] = image_details[
+                            "image_identifier"
+                        ]
 
             if "R" in image_details["kernel"]:
                 if "r" not in legacy_runtime_image_map:
@@ -252,16 +266,22 @@ def _get_runtimes_v2(runtimes, editor="Workbench", edition="Standard"):
                 else:
                     if image_details["kernel"] > legacy_runtime_kernel_map["r"]:
                         legacy_runtime_kernel_map["r"] = image_details["kernel"]
-                        legacy_runtime_image_map["r"] = image_details["image_identifier"]
+                        legacy_runtime_image_map["r"] = image_details[
+                            "image_identifier"
+                        ]
 
             if "Scala" in image_details["kernel"]:
                 if "scala" not in legacy_runtime_image_map:
                     legacy_runtime_kernel_map["scala"] = image_details["kernel"]
-                    legacy_runtime_image_map["scala"] = image_details["image_identifier"]
+                    legacy_runtime_image_map["scala"] = image_details[
+                        "image_identifier"
+                    ]
                 else:
                     if image_details["kernel"] > legacy_runtime_kernel_map["scala"]:
                         legacy_runtime_kernel_map["scala"] = image_details["kernel"]
-                        legacy_runtime_image_map["scala"] = image_details["image_identifier"]
+                        legacy_runtime_image_map["scala"] = image_details[
+                            "image_identifier"
+                        ]
 
     # Assigning Default runtime to Python3
     legacy_runtime_image_map["default"] = legacy_runtime_image_map["python3"]


### PR DESCRIPTION


Instead of checking with application name (to avoid duplicates), it can check with subdomain. So basically, it will skip creation of applications on the target workspace if the subdomain matches with any of the existing application.