### PR TITLE
DSE-28931 Add Spark Addon to all the workloads by default

### DIFF
--- a/cmlutils/constants.py
+++ b/cmlutils/constants.py
@@ -106,6 +106,6 @@ JOB_MAP = {
     "report.timeout_recipients": "timeout_recipients",
 }
 LEGACY_ENGINE = "legacy_engine"
-SPARK_ADDON = "spark320"
+SPARK_ADDON = "spark3"
 ORGANIZATION_TYPE = "organization"
 USER_TYPE = "user"


### PR DESCRIPTION
Currently, spark runtime addon is not being picked due to a minor search query error. This is now fixed by changing the default spark addon filter to spark3 instead of previous spark323.