### PR TITLE
expose actual ssh session error

### DIFF
--- a/cmlutils/ssh.py
+++ b/cmlutils/ssh.py
@@ -32,8 +32,8 @@ def open_ssh_endpoint(
     else:
         arr = line.split(" ")
         if len(arr) <= 3 or (not arr[3].isdigit()):
-            logging.error(ssh_call.stdout.readlines())
-            logging.error("SSH connection failed")
-            raise Exception("SSH connection failed")
+            logging.error("SSH connection failed unexpectedly: " + line)
+            logging.error(*ssh_call.stderr.readlines())
+            raise Exception("SSH connection failed unexpectedly")
         logging.info("SSH connection successfull")
         return ssh_call, int(arr[3])


### PR DESCRIPTION
Importing one of the projects was failing with "SSH session failed" error, and not until I made the proposed changes I was able to see that ssh was attempting to use port 5432 which was already taken (by Postgres also running on my bastion host).
With the change I was able to see the root cause:
```
28/03/2024 14:06:20 - ERROR - Project_P39 - SSH connection failed. Stopping session xkp30g58a2ppqq3y

28/03/2024 14:06:21 - ERROR - Project_P39 - can't listen on port 5432: listen tcp :5432: bind: address already in use
```

 