### PR TITLE
Fixes for several bugs and issues

### DIFF
--- a/cmlutils/base.py
+++ b/cmlutils/base.py
@@ -9,6 +9,9 @@ from cmlutils.utils import call_api_v1
 
 
 class BaseWorkspaceInteractor(object):
+    # use a variable to store the apiv2 key for repeated use instead
+    _apiv2_key = None
+
     def __init__(
         self,
         host: str,
@@ -27,6 +30,9 @@ class BaseWorkspaceInteractor(object):
 
     @property
     def apiv2_key(self) -> str:
+        if self._apiv2_key:
+            return self._apiv2_key
+
         endpoint = Template(ApiV1Endpoints.API_KEY.value).substitute(
             username=self.username
         )
@@ -44,8 +50,8 @@ class BaseWorkspaceInteractor(object):
             ca_path=self.ca_path,
         )
         response_dict = response.json()
-        _apiv2_key = response_dict["apiKey"]
-        return _apiv2_key
+        self._apiv2_key = response_dict["apiKey"]
+        return self._apiv2_key
 
     def remove_cdswctl_dir(self, file_path: str):
         if os.path.exists(file_path):

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -324,9 +324,11 @@ class ProjectExporter(BaseWorkspaceInteractor):
         # Handle Pagination if exists
         while next_page_exists:
             # Note - projectName param makes LIKE query not the exact match
+            # If projectname has back slashes, it need to be escaped before passing to the API
+            escaped_project_name = self.project_name.replace("\\", "\\\\")
             endpoint = Template(ApiV1Endpoints.PROJECTS_SUMMARY.value).substitute(
                 username=self.username,
-                projectName=self.project_name,
+                projectName=escaped_project_name,
                 limit=constants.MAX_API_PAGE_LENGTH,
                 offset=offset * constants.MAX_API_PAGE_LENGTH,
             )
@@ -930,9 +932,11 @@ class ProjectImporter(BaseWorkspaceInteractor):
         # Handle Pagination if exists
         while next_page_exists:
             # Note - projectName param makes LIKE query not the exact match
+            # If projectname has back slashes, it need to be escaped before passing to the API
+            escaped_project_name = self.project_name.replace("\\", "\\\\")
             endpoint = Template(ApiV1Endpoints.PROJECTS_SUMMARY.value).substitute(
                 username=self.username,
-                projectName=self.project_name,
+                projectName=escaped_project_name,
                 limit=constants.MAX_API_PAGE_LENGTH,
                 offset=offset * constants.MAX_API_PAGE_LENGTH,
             )

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -358,7 +358,10 @@ class ProjectExporter(BaseWorkspaceInteractor):
 
         if project_list:
             for project in project_list:
-                if project["name"] == self.project_name:
+                # If exporting from CDSW, it is possible that project lists can contain other users' projects,
+                # so there could be projects that has the same name but belong to other users. To ensure that
+                # we identify the correct project, we need to compare the project owner's name too.
+                if project["name"] == self.project_name and project["owner"]["username"] == self.username:
                     if project["owner"]["type"] == constants.ORGANIZATION_TYPE:
                         return (
                             project["owner"]["username"],

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -358,7 +358,7 @@ class ProjectExporter(BaseWorkspaceInteractor):
 
         if project_list:
             for project in project_list:
-                # If exporting from CDSW, it is possible that project lists can contain other users' projects,
+                # It is possible that project lists can contain other users' public projects, or team's projects
                 # so there could be projects that has the same name but belong to other users. To ensure that
                 # we identify the correct project, we need to compare the project owner's name too.
                 if project["name"] == self.project_name and project["owner"]["username"] == self.username:
@@ -1246,7 +1246,7 @@ class ProjectImporter(BaseWorkspaceInteractor):
             return result_list
         return None
 
-    def check_project_exist(self, project_name: str) -> str:
+    def check_project_exist(self, project_name: str, team_name: str = None) -> str:
         try:
             search_option = {"name": project_name}
             encoded_option = urllib.parse.quote(
@@ -1263,9 +1263,19 @@ class ProjectImporter(BaseWorkspaceInteractor):
                 ca_path=self.ca_path,
             )
             project_list = response.json()["projects"]
+
+            # If the project is a team's project, then the owner of the project is the team
+            if team_name:
+                owner = team_name
+            else:
+                owner = self.username
+
+            # It is possible that project lists can contain other users' public projects, or team's projects
+            # so there could be projects that has the same name but belong to other users. To ensure that
+            # we identify the correct project, we need to compare the project owner's name too.
             if project_list:
                 for project in project_list:
-                    if project["name"] == project_name:
+                    if project["name"] == project_name and project["owner"]["username"] == owner:
                         return project["id"]
             return None
         except KeyError as e:


### PR DESCRIPTION
This pull request contains fixes for the following issues:

1. When exporting projects, cmlutil may select the wrong project if there are projects with same name but owned by different users. This scenario occurs when:
  a) there are public project owned by another user and has the same project name
  b) user is part of a team and there is a team project that has the same project name
  c) exporting from CDSW; the list project API from CDSW include projects of other users if the API key is from an admin

2. DSE-37305: if importing a team's project, cmlutil will try to generate an apiv2 key using a team's username which result in 500 server error.

3. cmlutil is unable to export project if the project name contain back slash.