### PR TITLE
DSE-50960: Support for insecure connections and migration of other owner's projects

### DIFF
--- a/cmlutils/base.py
+++ b/cmlutils/base.py
@@ -17,6 +17,7 @@ class BaseWorkspaceInteractor(object):
         api_key: str,
         ca_path: str,
         project_slug: str,
+        skip_tls_verification: bool = False,
     ) -> None:
         self.host = host
         self.username = username
@@ -24,6 +25,7 @@ class BaseWorkspaceInteractor(object):
         self.api_key = api_key
         self.ca_path = ca_path
         self.project_slug = project_slug
+        self.skip_tls_verification = skip_tls_verification
 
     @property
     def apiv2_key(self) -> str:
@@ -42,6 +44,7 @@ class BaseWorkspaceInteractor(object):
             api_key=self.api_key,
             json_data=json_data,
             ca_path=self.ca_path,
+            skip_tls_verification=self.skip_tls_verification,
         )
         response_dict = response.json()
         _apiv2_key = response_dict["apiKey"]

--- a/cmlutils/cdswctl.py
+++ b/cmlutils/cdswctl.py
@@ -62,6 +62,5 @@ def obtain_cdswctl(host: str, ca_path: str) -> str:
 
 def cdswctl_login(cdswctl_path: str, host: str, username: str, api_key: str):
     logging.info("Logging into cdsw via cdswctl")
-    return subprocess.run(
-        [cdswctl_path, "login", "-n", username, "-u", host, "-y", api_key]
-    )
+    command = [cdswctl_path, "login", "-n", username, "-u", host, "-y", api_key]
+    return subprocess.run(command)

--- a/cmlutils/cdswctl.py
+++ b/cmlutils/cdswctl.py
@@ -23,11 +23,11 @@ def _get_cdswctl_download_url(host: str) -> str:
     return final_url
 
 
-def _download_and_extract(url: str, ca_path: str):
+def _download_and_extract(url: str, ca_path: str, skip_tls_verification: bool = False):
     file_name = url.split("/")[-1]
     dir_path = _cdswctl_tmp_dir_path()
     file_path = os.path.join(dir_path, file_name)
-    download_file(url=url, filepath=file_path, ca_path=ca_path)
+    download_file(url=url, filepath=file_path, ca_path=ca_path, skip_tls_verification=skip_tls_verification)
     if Path(constants.BASE_PATH_CDSWCTL) in Path(dir_path).parents:
         tf = tarfile.open(file_path)
         tf.extractall(dir_path)
@@ -51,9 +51,9 @@ def _cdswctl_tmp_dir_path() -> str:
     return dirpath
 
 
-def obtain_cdswctl(host: str, ca_path: str) -> str:
+def obtain_cdswctl(host: str, ca_path: str, skip_tls_verification: bool = False) -> str:
     file_url = _get_cdswctl_download_url(host)
-    expected_cdswctl_path = _download_and_extract(file_url, ca_path=ca_path)
+    expected_cdswctl_path = _download_and_extract(file_url, ca_path=ca_path, skip_tls_verification=skip_tls_verification)
     logging.info(
         "Expected cdsw path for cdswctl for file transfer %s", expected_cdswctl_path
     )

--- a/cmlutils/constants.py
+++ b/cmlutils/constants.py
@@ -23,6 +23,7 @@ API_V1_KEY = "apiv1_key"
 OUTPUT_DIR_KEY = "output_dir"
 PROJECT_NAME_KEY = "project_name"
 CA_PATH_KEY = "ca_path"
+SKIP_TLS_VERIFICATION_KEY = "skip_tls_verification"
 MAX_API_PAGE_LENGTH = 30
 
 

--- a/cmlutils/constants.py
+++ b/cmlutils/constants.py
@@ -17,6 +17,7 @@ BASE_PATH_CDSWCTL = "/tmp/cdswctls"
 DEFAULT_ENTRIES = [".cache", ".local"]
 DEFAULT_IMPORTIGNORE_ENTRIES = [".snapshot", ".snapshot/"]
 USERNAME_KEY = "username"
+PROJECT_OWNER_USERNAME_KEY = "owner_username"
 URL_KEY = "url"
 API_V1_KEY = "apiv1_key"
 OUTPUT_DIR_KEY = "output_dir"
@@ -46,19 +47,19 @@ class ApiV2Endpoints(Enum):
 
 
 class ApiV1Endpoints(Enum):
-    PROJECT = "api/v1/projects/$username/$project_name"
-    PROJECT_ENV = "api/v1/projects/$username/$project_name/environment"
-    PROJECT_FILE = "api/v1/projects/$username/$project_name/files/$filename"
+    PROJECT = "api/v1/projects/$owner/$project_name"
+    PROJECT_ENV = "api/v1/projects/$owner/$project_name/environment"
+    PROJECT_FILE = "api/v1/projects/$owner/$project_name/files/$filename"
     MODELS_LIST = "/api/altus-ds-1/models/list-models"
-    JOBS_LIST = "/api/v1/projects/$username/$project_name/jobs"
-    APPS_LIST = "/api/v1/projects/$username/$project_name/applications"
+    JOBS_LIST = "/api/v1/projects/$owner/$project_name/jobs"
+    APPS_LIST = "/api/v1/projects/$owner/$project_name/applications"
     MODEL_INFO = "/api/altus-ds-1/models/get-model"
-    JOB_INFO = "/api/v1/projects/$username/$project_name/jobs/$job_id"
-    APP_INFO = "/api/v1/projects/$username/$project_name/applications/$app_id"
+    JOB_INFO = "/api/v1/projects/$owner/$project_name/jobs/$job_id"
+    APP_INFO = "/api/v1/projects/$owner/$project_name/applications/$app_id"
     API_KEY = "/api/v1/users/$username/apikey"
     RUNTIMES = "/api/v1/runtimes"
     USER_INFO = "/api/v1/users/$username"
-    PROJECTS_SUMMARY = "/api/v1/users/$username/projects-summary?all=true&context=$username&sortColumn=updated_at&projectName=$projectName&limit=$limit&offset=$offset"
+    PROJECTS_SUMMARY = "/api/v1/users/$username/projects-summary?all=true&scope=all&context=$username&sortColumn=updated_at&projectName=$projectName&limit=$limit&offset=$offset"
 
 
 """Mapping of old fields v1 to new fields of v2"""

--- a/cmlutils/project_entrypoint.py
+++ b/cmlutils/project_entrypoint.py
@@ -74,6 +74,9 @@ def _read_config_file(file_path: str, project_name: str):
                 raise
         output_config[CA_PATH_KEY] = config.get(project_name, CA_PATH_KEY, fallback="")
         output_config[PROJECT_OWNER_USERNAME_KEY] = config.get(project_name, PROJECT_OWNER_USERNAME_KEY, fallback=config.get(project_name, USERNAME_KEY))
+        output_config[constants.SKIP_TLS_VERIFICATION_KEY] = config.getboolean(
+            project_name, constants.SKIP_TLS_VERIFICATION_KEY, fallback=False
+        )
         return output_config
     else:
         print("Validation error: cannot find config file:", file_path)
@@ -106,6 +109,7 @@ def project_export_cmd(project_name):
     apiv1_key = config[API_V1_KEY]
     output_dir = config[OUTPUT_DIR_KEY]
     ca_path = config[CA_PATH_KEY]
+    skip_tls_verification = config[constants.SKIP_TLS_VERIFICATION_KEY]
 
     output_dir = get_absolute_path(output_dir)
     ca_path = get_absolute_path(ca_path)
@@ -124,6 +128,7 @@ def project_export_cmd(project_name):
             ca_path=ca_path,
             project_slug=project_name,
             owner_type="",
+            skip_tls_verification=skip_tls_verification,
         )
         creator_username, project_slug, owner_type = pobj.get_creator_username()
         if creator_username is None:
@@ -143,6 +148,7 @@ def project_export_cmd(project_name):
             apiv1_key=apiv1_key,
             ca_path=ca_path,
             project_slug=project_slug,
+            skip_tls_verification=skip_tls_verification,
         )
         for v in validators:
             validation_response = v.validate()
@@ -169,6 +175,7 @@ def project_export_cmd(project_name):
             ca_path=ca_path,
             project_slug=project_slug,
             owner_type=owner_type,
+            skip_tls_verification=skip_tls_verification,
         )
         start_time = time.time()
         pexport.transfer_project_files(log_filedir=log_filedir)
@@ -230,6 +237,7 @@ def project_import_cmd(project_name, verify):
     apiv1_key = config[API_V1_KEY]
     local_directory = config[OUTPUT_DIR_KEY]
     ca_path = config[CA_PATH_KEY]
+    skip_tls_verification = config[constants.SKIP_TLS_VERIFICATION_KEY]
     local_directory = get_absolute_path(local_directory)
     ca_path = get_absolute_path(ca_path)
     log_filedir = os.path.join(local_directory, project_name, "logs")
@@ -243,6 +251,7 @@ def project_import_cmd(project_name, verify):
         top_level_dir=local_directory,
         ca_path=ca_path,
         project_slug=project_name,
+        skip_tls_verification=skip_tls_verification,
     )
     logging.info("Started importing project: %s", project_name)
     try:
@@ -253,6 +262,7 @@ def project_import_cmd(project_name, verify):
             top_level_directory=local_directory,
             apiv1_key=apiv1_key,
             ca_path=ca_path,
+            skip_tls_verification=skip_tls_verification,
         )
         logging.info("Begin validating for import.")
         for v in validators:
@@ -300,6 +310,7 @@ def project_import_cmd(project_name, verify):
             top_level_dir=local_directory,
             ca_path=ca_path,
             project_slug=project_slug,
+            skip_tls_verification=skip_tls_verification,
         )
         start_time = time.time()
         if verify:

--- a/cmlutils/project_entrypoint.py
+++ b/cmlutils/project_entrypoint.py
@@ -331,15 +331,16 @@ def project_import_cmd(project_name, verify):
         # Transfer ownership to original owner if specified in metadata
         if "original_owner_username" in project_metadata and project_metadata["original_owner_username"]:
             original_owner = project_metadata["original_owner_username"]
-            logging.info("Attempting to transfer ownership to original owner: %s", original_owner)
-            try:
-                pimport.trasnfer_ownership_to_original_owner(original_owner_username=original_owner)
-            except Exception as e:
-                logging.warning(
-                    "Ownership transfer to %s failed but continuing with import. Error: %s",
-                    original_owner,
-                    str(e)
-                )
+            if original_owner != username:
+                logging.info("Attempting to transfer ownership to original owner: %s", original_owner)
+                try:
+                    pimport.trasnfer_ownership_to_original_owner(original_owner_username=original_owner)
+                except Exception as e:
+                    logging.warning(
+                        "Ownership transfer to %s failed but continuing with import. Error: %s",
+                        original_owner,
+                        str(e)
+                    )
         
         print("\033[32m✔ Import of Project {} Successful \033[0m".format(project_name))
         print(

--- a/cmlutils/projects.py
+++ b/cmlutils/projects.py
@@ -695,6 +695,7 @@ class ProjectExporter(BaseWorkspaceInteractor):
 
         project_metadata["template"] = "blank"
         project_metadata["environment"] = project_env
+        project_metadata["original_owner_username"] = self.project_owner_username
 
         # Create project in team context
         if self.owner_type == constants.ORGANIZATION_TYPE:

--- a/cmlutils/utils.py
+++ b/cmlutils/utils.py
@@ -19,6 +19,7 @@ def call_api_v1(
     api_key: str,
     json_data: dict = None,
     ca_path: str = "",
+    skip_tls_verification: bool = False,
 ) -> requests.Response:
     url = urllib.parse.urljoin(host, endpoint)
     s = requests.Session()
@@ -31,6 +32,15 @@ def call_api_v1(
     s.mount("https://", HTTPAdapter(max_retries=retries))
     headers = {"Content-Type": "application/json"}
     resp = None
+    
+    # Determine SSL verification setting
+    if skip_tls_verification:
+        verify_setting = False
+    elif ca_path != "":
+        verify_setting = ca_path
+    else:
+        verify_setting = True
+    
     try:
         if json_data != None:
             resp = s.request(
@@ -39,7 +49,7 @@ def call_api_v1(
                 auth=(api_key, ""),
                 headers=headers,
                 json=json_data,
-                verify=ca_path if ca_path != "" else True,
+                verify=verify_setting,
             )
         else:
             resp = s.request(
@@ -47,7 +57,7 @@ def call_api_v1(
                 url=url,
                 auth=(api_key, ""),
                 headers=headers,
-                verify=ca_path if ca_path != "" else True,
+                verify=verify_setting,
             )
         resp.raise_for_status()  # Raise an exception for 4xx or 5xx errors
         return resp
@@ -64,6 +74,7 @@ def call_api_v2(
     user_token: str,
     json_data: dict = None,
     ca_path: str = "",
+    skip_tls_verification: bool = False,
 ) -> requests.Response:
     url = urllib.parse.urljoin(host, endpoint)
     s = requests.Session()
@@ -79,6 +90,15 @@ def call_api_v2(
         "Authorization": "Bearer {}".format(user_token),
     }
     resp = None
+    
+    # Determine SSL verification setting
+    if skip_tls_verification:
+        verify_setting = False
+    elif ca_path != "":
+        verify_setting = ca_path
+    else:
+        verify_setting = True
+    
     try:
         if json_data != None:
             resp = s.request(
@@ -86,14 +106,14 @@ def call_api_v2(
                 url=url,
                 headers=headers,
                 json=json_data,
-                verify=ca_path if ca_path != "" else True,
+                verify=verify_setting,
             )
         else:
             resp = s.request(
                 method=method.upper(),
                 url=url,
                 headers=headers,
-                verify=ca_path if ca_path != "" else True,
+                verify=verify_setting,
             )
         resp.raise_for_status()  # Raise an exception for 4xx or 5xx errors
         return resp
@@ -104,8 +124,16 @@ def call_api_v2(
         raise
 
 
-def download_file(url: str, filepath: str, ca_path: str = ""):
-    with requests.get(url, stream=True, verify=ca_path if ca_path != "" else True) as r:
+def download_file(url: str, filepath: str, ca_path: str = "", skip_tls_verification: bool = False):
+    # Determine SSL verification setting
+    if skip_tls_verification:
+        verify_setting = False
+    elif ca_path != "":
+        verify_setting = ca_path
+    else:
+        verify_setting = True
+    
+    with requests.get(url, stream=True, verify=verify_setting) as r:
         with open(filepath, "wb") as f:
             shutil.copyfileobj(r.raw, f)
 

--- a/cmlutils/validator.py
+++ b/cmlutils/validator.py
@@ -238,7 +238,7 @@ class ProjectBelongsToUserValidator(ExportValidators):
 
     def validate(self) -> ValidationResponse:
         endpoint = Template(ApiV1Endpoints.PROJECT.value).substitute(
-            username=self.username, project_name=self.project_slug
+            owner=self.username, project_name=self.project_slug
         )
         try:
             response = call_api_v1(

--- a/cmlutils/validator.py
+++ b/cmlutils/validator.py
@@ -68,7 +68,7 @@ class DirectoriesAndFilesValidator(ImportValidators):
 
 class UserNameImportValidator(ImportValidators):
     def __init__(
-        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str
+        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str, skip_tls_verification: bool = False
     ):
         self.validation_name = "check if user is present"
         self.host = host
@@ -76,6 +76,7 @@ class UserNameImportValidator(ImportValidators):
         self.apiv1_key = apiv1_key
         self.project_name = project_name
         self.ca_path = ca_path
+        self.skip_tls_verification = skip_tls_verification
 
     def validate(self) -> ValidationResponse:
         endpoint = Template(ApiV1Endpoints.USER_INFO.value).substitute(
@@ -88,6 +89,7 @@ class UserNameImportValidator(ImportValidators):
                 method="GET",
                 api_key=self.apiv1_key,
                 ca_path=self.ca_path,
+                skip_tls_verification=self.skip_tls_verification,
             )
             return ValidationResponse(
                 validation_name=self.validation_name,
@@ -125,7 +127,7 @@ class UserNameImportValidator(ImportValidators):
 
 class RsyncRuntimeAddonExistsImportValidator(ImportValidators):
     def __init__(
-        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str
+        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str, skip_tls_verification: bool = False
     ):
         self.validation_name = "check if rsync is present"
         self.host = host
@@ -133,11 +135,12 @@ class RsyncRuntimeAddonExistsImportValidator(ImportValidators):
         self.apiv1_key = apiv1_key
         self.project_name = project_name
         self.ca_path = ca_path
+        self.skip_tls_verification = skip_tls_verification
 
     def validate(self) -> ValidationResponse:
         rsync_enabled_runtime_id = -1
         rsync_enabled_runtime_id = get_rsync_enabled_runtime_id(
-            host=self.host, api_key=self.apiv1_key, ca_path=self.ca_path
+            host=self.host, api_key=self.apiv1_key, ca_path=self.ca_path, skip_tls_verification=self.skip_tls_verification
         )
         if rsync_enabled_runtime_id != -1:
             return ValidationResponse(
@@ -160,7 +163,7 @@ class ExportValidators(metaclass=ABCMeta):
 
 class UsernameValidator(ExportValidators):
     def __init__(
-        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str
+        self, host: str, username: str, apiv1_key: str, project_name: str, ca_path: str, skip_tls_verification: bool = False
     ):
         self.validation_name = "check if user is present"
         self.host = host
@@ -168,6 +171,7 @@ class UsernameValidator(ExportValidators):
         self.apiv1_key = apiv1_key
         self.project_name = project_name
         self.ca_path = ca_path
+        self.skip_tls_verification = skip_tls_verification
 
     def validate(self) -> ValidationResponse:
         endpoint = Template(ApiV1Endpoints.USER_INFO.value).substitute(
@@ -180,6 +184,7 @@ class UsernameValidator(ExportValidators):
                 method="GET",
                 api_key=self.apiv1_key,
                 ca_path=self.ca_path,
+                skip_tls_verification=self.skip_tls_verification,
             )
             return ValidationResponse(
                 validation_name=self.validation_name,
@@ -224,6 +229,7 @@ class ProjectBelongsToUserValidator(ExportValidators):
         project_name: str,
         ca_path: str,
         project_slug: str,
+        skip_tls_verification: bool = False,
     ):
         self.validation_name = "Validate if the project {} belongs to user {}".format(
             project_name, username
@@ -235,6 +241,7 @@ class ProjectBelongsToUserValidator(ExportValidators):
         self.project_name = project_name
         self.ca_path = ca_path
         self.project_slug = project_slug
+        self.skip_tls_verification = skip_tls_verification
 
     def validate(self) -> ValidationResponse:
         endpoint = Template(ApiV1Endpoints.PROJECT.value).substitute(
@@ -247,6 +254,7 @@ class ProjectBelongsToUserValidator(ExportValidators):
                 method="GET",
                 api_key=self.apiv1_key,
                 ca_path=self.ca_path,
+                skip_tls_verification=self.skip_tls_verification,
             )
             return ValidationResponse(
                 validation_name=self.validation_name,
@@ -292,6 +300,7 @@ class RsyncRuntimeAddonExistsExportValidator(ExportValidators):
         project_name: str,
         ca_path: str,
         project_slug: str,
+        skip_tls_verification: bool = False,
     ):
         self.validation_name = "check if rsync is present"
         self.host = host
@@ -300,6 +309,7 @@ class RsyncRuntimeAddonExistsExportValidator(ExportValidators):
         self.project_name = project_name
         self.ca_path = ca_path
         self.project_slug = project_slug
+        self.skip_tls_verification = skip_tls_verification
 
     def validate(self) -> ValidationResponse:
         rsync_enabled_runtime_id = -1
@@ -310,9 +320,10 @@ class RsyncRuntimeAddonExistsExportValidator(ExportValidators):
             api_key=self.apiv1_key,
             ca_path=self.ca_path,
             project_slug=self.project_slug,
+            skip_tls_verification=self.skip_tls_verification,
         ):
             rsync_enabled_runtime_id = get_rsync_enabled_runtime_id(
-                host=self.host, api_key=self.apiv1_key, ca_path=self.ca_path
+                host=self.host, api_key=self.apiv1_key, ca_path=self.ca_path, skip_tls_verification=self.skip_tls_verification
             )
             if rsync_enabled_runtime_id != -1:
                 return ValidationResponse(
@@ -344,6 +355,7 @@ def initialize_import_validators(
     top_level_directory: str,
     apiv1_key: str,
     ca_path: str,
+    skip_tls_verification: bool = False,
 ) -> List[ImportValidators]:
     return [
         DirectoriesAndFilesValidator(
@@ -357,6 +369,7 @@ def initialize_import_validators(
             apiv1_key=apiv1_key,
             project_name=project_name,
             ca_path=ca_path,
+            skip_tls_verification=skip_tls_verification,
         ),
         RsyncRuntimeAddonExistsImportValidator(
             host=host,
@@ -364,6 +377,7 @@ def initialize_import_validators(
             apiv1_key=apiv1_key,
             project_name=project_name,
             ca_path=ca_path,
+            skip_tls_verification=skip_tls_verification,
         ),
     ]
 
@@ -376,6 +390,7 @@ def initialize_export_validators(
     apiv1_key: str,
     ca_path: str,
     project_slug: str,
+    skip_tls_verification: bool = False,
 ) -> List[ExportValidators]:
     return [
         TopLevelDirectoryValidator(top_level_directory=top_level_directory),
@@ -385,6 +400,7 @@ def initialize_export_validators(
             apiv1_key=apiv1_key,
             project_name=project_name,
             ca_path=ca_path,
+            skip_tls_verification=skip_tls_verification,
         ),
         ProjectBelongsToUserValidator(
             host=host,
@@ -393,6 +409,7 @@ def initialize_export_validators(
             project_name=project_name,
             ca_path=ca_path,
             project_slug=project_slug,
+            skip_tls_verification=skip_tls_verification,
         ),
         RsyncRuntimeAddonExistsExportValidator(
             host=host,
@@ -401,5 +418,6 @@ def initialize_export_validators(
             project_name=project_name,
             ca_path=ca_path,
             project_slug=project_slug,
+            skip_tls_verification=skip_tls_verification,
         ),
     ]


### PR DESCRIPTION
Changes:
- We now support export of project owned by other users/teams given the cmlutil user has some kind of write access to the project.
  - To use this feature, provide an (optional) field under the project name in `export-config.ini` called `owner_username`. If this field is not present, then the project is assumed to be owned by whatever `username` is specified in the config.
  - We save the original owner of the project in `project-metadata.json` under a new field called `original_owner_username`. This field is used to attempt changing ownership again to original owner during import at the destination workspace.
- On the import side, we will attempt changing the ownership of the project to the same username which was there at the exporting workspace. If the username is not available at the import side, we will just log "Ownership transfer couldn't be completed because user <original-user> is not available in destination workspace" and leave the ownership to the cmlutil user.
- We added a new field in `export-config.ini`/`import-config.ini` to skip TLS verification. To use untrusted API calls, add `skip_tls_verification=true` either under specific project or globally throughout the configuration.

New export configuration file looks like:
```ini
[DEFAULT]
url=<url>
output_dir=~/.cmlutils/tmp
source_dir=~/.cmlutils/tmp
ca_path=<cert-path>
username=csso_ritwik
apiv1_key=<api-key>

[Project A]

[Project B owned by another user]
owner_username=<other-username> ; optional

[Project C owned by a team]
owner_username=<team name> ; optional

[project D requiring insecure API calls]
skip_tls_verification=true ; optional
```


Test matrix:

- Project owned by cmlutil user
   - *Expected Result*: Import/export same as before.
- Project owned by different user on exporting workspace
   - Original owner username present in importing workspace
      -  *Expected Result*: After import, ownership changes to the original owner's username
   - Original owner username NOT present in importing workspace
      -  *Expected Result*: We just log the unavailability of original user at destination workspace and keep the cmlutil user as owner
- Test with `skip_tls_verification=true` and don't pass CA certificate path.