### PR TITLE
DSE-56135: Find free port before spawning cdswctl

### DIFF
--- a/cmlutils/ssh.py
+++ b/cmlutils/ssh.py
@@ -1,12 +1,20 @@
 import logging
 import signal
+import socket
 import subprocess
 import time
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 def open_ssh_endpoint(
     cdswctl_path: str, project_name: str, runtime_id: int, project_slug: str
 ) -> tuple[subprocess.Popen, int]:
+    local_port = _find_free_port()
     command = [
         cdswctl_path,
         "ssh-endpoint",
@@ -16,6 +24,8 @@ def open_ssh_endpoint(
         "1.0",
         "-m",
         "0.5",
+        "--port",
+        str(local_port),
     ]
     if runtime_id != -1:
         command.append("-r")


### PR DESCRIPTION
Jira - [DSE-56135](https://cloudera.atlassian.net/browse/DSE-56135)

Description:

When running cmlutils to export CML projects, cdswctl ssh-endpoint always tries to bind to local port 4555. If that port is occupied by another process, the export fails with:

can't listen on port 4555: listen tcp :4555: bind: address already in use

Root Cause

cdswctl ssh-endpoint defaults to port 4555. With no port override in the cmlutils invocation, any process already holding 4555 on the same machine will permanently block all exports.

Fix

In cmlutils/ssh.py, eliminate fixed-port conflict by finding a OS-assigned free port before spawning cdswctl
